### PR TITLE
Add countdown module with Jest test

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+node_modules/
+package-lock.json

--- a/assets/countdown.js
+++ b/assets/countdown.js
@@ -1,0 +1,24 @@
+function updateCountdown(countdown, targetDate) {
+  const now = new Date();
+  const diff = targetDate - now;
+  const setText = (text) => {
+    countdown.textContent = text;
+    countdown.innerText = text;
+  };
+  if (diff <= 0) {
+    setText("Drop is Live.");
+  } else {
+    const days = Math.floor(diff / (1000 * 60 * 60 * 24));
+    const hours = Math.floor((diff / (1000 * 60 * 60)) % 24);
+    const minutes = Math.floor((diff / (1000 * 60)) % 60);
+    const seconds = Math.floor((diff / 1000) % 60);
+    setText(`${days}d ${hours}h ${minutes}m ${seconds}s`);
+  }
+}
+
+if (typeof module !== 'undefined') {
+  module.exports = { updateCountdown };
+}
+if (typeof window !== 'undefined') {
+  window.updateCountdown = updateCountdown;
+}

--- a/countdown.test.js
+++ b/countdown.test.js
@@ -1,0 +1,17 @@
+/**
+ * @jest-environment jsdom
+ */
+const { updateCountdown } = require('./assets/countdown');
+
+describe('updateCountdown', () => {
+  test('updates element with remaining time', () => {
+    jest.useFakeTimers();
+    const now = new Date('2025-05-30T00:00:00Z');
+    jest.setSystemTime(now);
+    const elem = document.createElement('div');
+    const targetDate = new Date('2025-06-01T00:00:00Z');
+    updateCountdown(elem, targetDate);
+    expect(elem.textContent).toBe('2d 0h 0m 0s');
+    jest.useRealTimers();
+  });
+});

--- a/index.html
+++ b/index.html
@@ -165,25 +165,12 @@
     <source src="assets/audio/flvr404-bg-glitch.mp3" type="audio/mpeg" />
   </audio>
 
+  <script src="assets/countdown.js"></script>
   <script>
     const countdown = document.getElementById("countdown");
     const targetDate = new Date("2025-06-01T00:00:00+07:00");
 
-    function updateCountdown() {
-      const now = new Date();
-      const diff = targetDate - now;
-      if (diff <= 0) {
-        countdown.innerText = "Drop is Live.";
-      } else {
-        const days = Math.floor(diff / (1000 * 60 * 60 * 24));
-        const hours = Math.floor((diff / (1000 * 60 * 60)) % 24);
-        const minutes = Math.floor((diff / (1000 * 60)) % 60);
-        const seconds = Math.floor((diff / 1000) % 60);
-        countdown.innerText = `${days}d ${hours}h ${minutes}m ${seconds}s`;
-      }
-    }
-
-    setInterval(updateCountdown, 1000);
+    setInterval(() => updateCountdown(countdown, targetDate), 1000);
 
     // Trigger audio on first user interaction
     window.addEventListener('click', () => {

--- a/package.json
+++ b/package.json
@@ -1,0 +1,17 @@
+{
+  "name": "flvr404-site",
+  "version": "1.0.0",
+  "description": "",
+  "main": "index.js",
+  "scripts": {
+    "test": "jest"
+  },
+  "keywords": [],
+  "author": "",
+  "license": "ISC",
+  "type": "commonjs",
+  "devDependencies": {
+    "jest": "^29.7.0",
+    "jest-environment-jsdom": "^30.0.0-beta.3"
+  }
+}


### PR DESCRIPTION
## Summary
- initialize Node/Jest environment
- extract countdown timer logic to `assets/countdown.js`
- load new script from `index.html`
- add Jest test verifying countdown output
- ignore `node_modules` and `package-lock.json`

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6840472200f88328952484df2874337e